### PR TITLE
updated schema/datamodel to include saved on events/users, added save…

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -17,20 +17,20 @@ const resolvers = {
   //prisma bindings, otherwise fields would be null in queries/mutations
   Event: {
     creator: (parent, args, {prisma}) =>
-      prisma.event({id: parent.id}).creator(),
+      prisma.event({id: parent.id}).creator({...args}),
     eventImages: (parent, args, {prisma}) =>
-      prisma.event({id: parent.id}).eventImages(),
-    rsvps: (parent, args, {prisma}) => prisma.event({id: parent.id}).rsvps(),
-    saved: (parent, args, {prisma}) => prisma.event({id: parent.id}).saved(),
-    urls: (parent, args, {prisma}) => prisma.event({id: parent.id}).urls(),
-    admins: (parent, args, {prisma}) => prisma.event({id: parent.id}).admins(),
+      prisma.event({id: parent.id}).eventImages({...args}),
+    rsvps: (parent, args, {prisma}) => prisma.event({id: parent.id}).rsvps({...args}),
+    saved: (parent, args, {prisma}) => prisma.event({id: parent.id}).saved({...args}),
+    urls: (parent, args, {prisma}) => prisma.event({id: parent.id}).urls({...args}),
+    admins: (parent, args, {prisma}) => prisma.event({id: parent.id}).admins({...args}),
     locations: async (
       parent,
       {userLatitude, userLongitude, distanceUnit = 'miles', ...args},
       {prisma},
     ) => {
       // find the locations for the current event
-      const eventLocations = await prisma.event({id: parent.id}).locations();
+      const eventLocations = await prisma.event({id: parent.id}).locations({...args});
 
       //if userLatitude and userLongitude are passed as arguments for location
       if (userLatitude && userLongitude) {
@@ -58,15 +58,15 @@ const resolvers = {
 
       return eventLocations;
     },
-    tags: (parent, args, {prisma}) => prisma.event({id: parent.id}).tags(),
+    tags: (parent, args, {prisma}) => prisma.event({id: parent.id}).tags({...args}),
   },
   User: {
-    rsvps: (parent, args, {prisma}) => prisma.user({id: parent.id}).rsvps(),
+    rsvps: (parent, args, {prisma}) => prisma.user({id: parent.id}).rsvps({...args}),
     createdImages: (parent, args, {prisma}) =>
-      prisma.user({id: parent.id}).createdImages(),
+      prisma.user({id: parent.id}).createdImages({...args}),
   },
   Tag: {
-    events: (parent, args, {prisma}) => prisma.tag({id: parent.id}).events(),
+    events: (parent, args, {prisma}) => prisma.tag({id: parent.id}).events({...args}),
   },
   Query: {
     users: async (root, args, {prisma, req, decodedToken}, info) => {

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -27,6 +27,7 @@ input EventCreateInput {
   end: DateTime!
   eventImages: [EventCreateImageInput!]
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admin: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -41,6 +42,7 @@ input EventUpdateInput {
   end: DateTime
   eventImages: [EventCreateImageInput!]
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -76,6 +78,11 @@ input SearchFilters {
   dateRange: DateRangeSearchInput
 }
 
+enum Saved {
+  SAVED
+  UNSAVED
+}
+
 type Location {
   id: ID!
   name: String!
@@ -102,6 +109,7 @@ type Event {
   ticketPrice: Float!
   eventImages(where: EventImageWhereInput, orderBy: EventImageOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventImage!]
   rsvps(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
+  saved(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   urls(where: EventUrlWhereInput, orderBy: EventUrlOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventUrl!]
   admins(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   locations(
@@ -192,5 +200,6 @@ type Mutation {
   deleteEvent(where: EventWhereUniqueInput!): Event
   addRsvp(event: EventIdInput!): User
   removeRsvp(event: EventIdInput!): User
+  saveEvent(event: EventIdInput!): Saved!
 }
 

--- a/prisma-client/datamodel.prisma
+++ b/prisma-client/datamodel.prisma
@@ -5,6 +5,7 @@ type User {
   auth0Id: String! @unique
   organizations: [Organization!] @relation(name: "UsersOrganizations", link: TABLE)
   rsvps: [Event!] @relation(name: "UsersRsvps", link: TABLE)
+  saved: [Event!] @relation(name: "UsersSavedEvents", link: TABLE)
   adminFor: [Event!] @relation(name: "EventsAdmins", link: TABLE)
   createdEvents: [Event!] @relation(name: "CreatedEvents", link: TABLE, onDelete: CASCADE)
   createdImages: [EventImage!] @relation(name: "CreatedImages", link: TABLE, onDelete: CASCADE)
@@ -20,6 +21,7 @@ type Event {
   creator: User @relation(name: "CreatedEvents")
   eventImages: [EventImage!] @relation(name: "EventsImages", link: TABLE, onDelete: CASCADE)
   rsvps: [User!] @relation(name: "UsersRsvps")
+  saved: [User!] @relation(name: "UsersSavedEvents")
   urls: [EventUrl!] @relation(name: "EventUrls", link: TABLE, onDelete: CASCADE)
   admins: [User!] @relation(name: "EventsAdmins")
   locations: [Location!] @relation(name: "EventsLocations", link: TABLE, onDelete: CASCADE)

--- a/prisma-client/generated/prisma-client/index.d.ts
+++ b/prisma-client/generated/prisma-client/index.d.ts
@@ -649,6 +649,9 @@ export interface UserWhereInput {
   rsvps_every?: Maybe<EventWhereInput>;
   rsvps_some?: Maybe<EventWhereInput>;
   rsvps_none?: Maybe<EventWhereInput>;
+  saved_every?: Maybe<EventWhereInput>;
+  saved_some?: Maybe<EventWhereInput>;
+  saved_none?: Maybe<EventWhereInput>;
   adminFor_every?: Maybe<EventWhereInput>;
   adminFor_some?: Maybe<EventWhereInput>;
   adminFor_none?: Maybe<EventWhereInput>;
@@ -737,6 +740,9 @@ export interface EventWhereInput {
   rsvps_every?: Maybe<UserWhereInput>;
   rsvps_some?: Maybe<UserWhereInput>;
   rsvps_none?: Maybe<UserWhereInput>;
+  saved_every?: Maybe<UserWhereInput>;
+  saved_some?: Maybe<UserWhereInput>;
+  saved_none?: Maybe<UserWhereInput>;
   urls_every?: Maybe<EventUrlWhereInput>;
   urls_some?: Maybe<EventUrlWhereInput>;
   urls_none?: Maybe<EventUrlWhereInput>;
@@ -1095,6 +1101,7 @@ export interface EventCreateInput {
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
@@ -1114,6 +1121,7 @@ export interface UserCreateWithoutCreatedEventsInput {
   auth0Id: String;
   organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
   rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
   adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
   createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
 }
@@ -1149,6 +1157,7 @@ export interface EventCreateWithoutRsvpsInput {
   ticketPrice: Float;
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
@@ -1181,8 +1190,48 @@ export interface UserCreateWithoutCreatedImagesInput {
   auth0Id: String;
   organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
   rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
   adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
+}
+
+export interface EventCreateManyWithoutSavedInput {
+  create?: Maybe<EventCreateWithoutSavedInput[] | EventCreateWithoutSavedInput>;
+  connect?: Maybe<EventWhereUniqueInput[] | EventWhereUniqueInput>;
+}
+
+export interface EventCreateWithoutSavedInput {
+  id?: Maybe<ID_Input>;
+  title: String;
+  description: String;
+  start: DateTimeInput;
+  end: DateTimeInput;
+  ticketPrice: Float;
+  creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
+  eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
+  rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
+  admins?: Maybe<UserCreateManyWithoutAdminForInput>;
+  locations?: Maybe<LocationCreateManyWithoutEventInput>;
+  tags?: Maybe<TagCreateManyWithoutEventsInput>;
+  index: String;
+}
+
+export interface UserCreateManyWithoutRsvpsInput {
+  create?: Maybe<UserCreateWithoutRsvpsInput[] | UserCreateWithoutRsvpsInput>;
+  connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+}
+
+export interface UserCreateWithoutRsvpsInput {
+  id?: Maybe<ID_Input>;
+  firstName?: Maybe<String>;
+  lastName?: Maybe<String>;
+  auth0Id: String;
+  organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
+  adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
+  createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
+  createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
 }
 
 export interface EventCreateManyWithoutAdminsInput {
@@ -1202,23 +1251,25 @@ export interface EventCreateWithoutAdminsInput {
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
   tags?: Maybe<TagCreateManyWithoutEventsInput>;
   index: String;
 }
 
-export interface UserCreateManyWithoutRsvpsInput {
-  create?: Maybe<UserCreateWithoutRsvpsInput[] | UserCreateWithoutRsvpsInput>;
+export interface UserCreateManyWithoutSavedInput {
+  create?: Maybe<UserCreateWithoutSavedInput[] | UserCreateWithoutSavedInput>;
   connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
 }
 
-export interface UserCreateWithoutRsvpsInput {
+export interface UserCreateWithoutSavedInput {
   id?: Maybe<ID_Input>;
   firstName?: Maybe<String>;
   lastName?: Maybe<String>;
   auth0Id: String;
   organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
+  rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
   adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
@@ -1240,6 +1291,7 @@ export interface EventCreateWithoutCreatorInput {
   ticketPrice: Float;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
@@ -1273,6 +1325,7 @@ export interface UserCreateWithoutAdminForInput {
   auth0Id: String;
   organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
   rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
   createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
 }
@@ -1304,6 +1357,7 @@ export interface EventCreateWithoutEventImagesInput {
   ticketPrice: Float;
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
@@ -1370,6 +1424,7 @@ export interface EventUpdateInput {
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
@@ -1392,6 +1447,7 @@ export interface UserUpdateWithoutCreatedEventsDataInput {
   auth0Id?: Maybe<String>;
   organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
   rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
   adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
   createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
 }
@@ -1564,6 +1620,7 @@ export interface EventUpdateWithoutRsvpsDataInput {
   ticketPrice?: Maybe<Float>;
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
@@ -1617,8 +1674,86 @@ export interface UserUpdateWithoutCreatedImagesDataInput {
   auth0Id?: Maybe<String>;
   organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
   rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
   adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
+}
+
+export interface EventUpdateManyWithoutSavedInput {
+  create?: Maybe<EventCreateWithoutSavedInput[] | EventCreateWithoutSavedInput>;
+  delete?: Maybe<EventWhereUniqueInput[] | EventWhereUniqueInput>;
+  connect?: Maybe<EventWhereUniqueInput[] | EventWhereUniqueInput>;
+  set?: Maybe<EventWhereUniqueInput[] | EventWhereUniqueInput>;
+  disconnect?: Maybe<EventWhereUniqueInput[] | EventWhereUniqueInput>;
+  update?: Maybe<
+    | EventUpdateWithWhereUniqueWithoutSavedInput[]
+    | EventUpdateWithWhereUniqueWithoutSavedInput
+  >;
+  upsert?: Maybe<
+    | EventUpsertWithWhereUniqueWithoutSavedInput[]
+    | EventUpsertWithWhereUniqueWithoutSavedInput
+  >;
+  deleteMany?: Maybe<EventScalarWhereInput[] | EventScalarWhereInput>;
+  updateMany?: Maybe<
+    EventUpdateManyWithWhereNestedInput[] | EventUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface EventUpdateWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput;
+  data: EventUpdateWithoutSavedDataInput;
+}
+
+export interface EventUpdateWithoutSavedDataInput {
+  title?: Maybe<String>;
+  description?: Maybe<String>;
+  start?: Maybe<DateTimeInput>;
+  end?: Maybe<DateTimeInput>;
+  ticketPrice?: Maybe<Float>;
+  creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
+  eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
+  rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
+  admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
+  locations?: Maybe<LocationUpdateManyWithoutEventInput>;
+  tags?: Maybe<TagUpdateManyWithoutEventsInput>;
+  index?: Maybe<String>;
+}
+
+export interface UserUpdateManyWithoutRsvpsInput {
+  create?: Maybe<UserCreateWithoutRsvpsInput[] | UserCreateWithoutRsvpsInput>;
+  delete?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+  connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+  set?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+  disconnect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
+  update?: Maybe<
+    | UserUpdateWithWhereUniqueWithoutRsvpsInput[]
+    | UserUpdateWithWhereUniqueWithoutRsvpsInput
+  >;
+  upsert?: Maybe<
+    | UserUpsertWithWhereUniqueWithoutRsvpsInput[]
+    | UserUpsertWithWhereUniqueWithoutRsvpsInput
+  >;
+  deleteMany?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
+  updateMany?: Maybe<
+    UserUpdateManyWithWhereNestedInput[] | UserUpdateManyWithWhereNestedInput
+  >;
+}
+
+export interface UserUpdateWithWhereUniqueWithoutRsvpsInput {
+  where: UserWhereUniqueInput;
+  data: UserUpdateWithoutRsvpsDataInput;
+}
+
+export interface UserUpdateWithoutRsvpsDataInput {
+  firstName?: Maybe<String>;
+  lastName?: Maybe<String>;
+  auth0Id?: Maybe<String>;
+  organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
+  adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
+  createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
+  createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
 }
 
 export interface EventUpdateManyWithoutAdminsInput {
@@ -1657,25 +1792,26 @@ export interface EventUpdateWithoutAdminsDataInput {
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
   tags?: Maybe<TagUpdateManyWithoutEventsInput>;
   index?: Maybe<String>;
 }
 
-export interface UserUpdateManyWithoutRsvpsInput {
-  create?: Maybe<UserCreateWithoutRsvpsInput[] | UserCreateWithoutRsvpsInput>;
+export interface UserUpdateManyWithoutSavedInput {
+  create?: Maybe<UserCreateWithoutSavedInput[] | UserCreateWithoutSavedInput>;
   delete?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
   connect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
   set?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
   disconnect?: Maybe<UserWhereUniqueInput[] | UserWhereUniqueInput>;
   update?: Maybe<
-    | UserUpdateWithWhereUniqueWithoutRsvpsInput[]
-    | UserUpdateWithWhereUniqueWithoutRsvpsInput
+    | UserUpdateWithWhereUniqueWithoutSavedInput[]
+    | UserUpdateWithWhereUniqueWithoutSavedInput
   >;
   upsert?: Maybe<
-    | UserUpsertWithWhereUniqueWithoutRsvpsInput[]
-    | UserUpsertWithWhereUniqueWithoutRsvpsInput
+    | UserUpsertWithWhereUniqueWithoutSavedInput[]
+    | UserUpsertWithWhereUniqueWithoutSavedInput
   >;
   deleteMany?: Maybe<UserScalarWhereInput[] | UserScalarWhereInput>;
   updateMany?: Maybe<
@@ -1683,16 +1819,17 @@ export interface UserUpdateManyWithoutRsvpsInput {
   >;
 }
 
-export interface UserUpdateWithWhereUniqueWithoutRsvpsInput {
+export interface UserUpdateWithWhereUniqueWithoutSavedInput {
   where: UserWhereUniqueInput;
-  data: UserUpdateWithoutRsvpsDataInput;
+  data: UserUpdateWithoutSavedDataInput;
 }
 
-export interface UserUpdateWithoutRsvpsDataInput {
+export interface UserUpdateWithoutSavedDataInput {
   firstName?: Maybe<String>;
   lastName?: Maybe<String>;
   auth0Id?: Maybe<String>;
   organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
+  rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
   adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
@@ -1733,6 +1870,7 @@ export interface EventUpdateWithoutCreatorDataInput {
   ticketPrice?: Maybe<Float>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
@@ -1854,6 +1992,7 @@ export interface UserUpdateWithoutAdminForDataInput {
   auth0Id?: Maybe<String>;
   organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
   rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
   createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
 }
@@ -1908,6 +2047,7 @@ export interface EventUpdateWithoutEventImagesDataInput {
   ticketPrice?: Maybe<Float>;
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
@@ -2442,16 +2582,28 @@ export interface EventUpdateManyDataInput {
   index?: Maybe<String>;
 }
 
-export interface UserUpsertWithWhereUniqueWithoutRsvpsInput {
+export interface UserUpsertWithWhereUniqueWithoutSavedInput {
   where: UserWhereUniqueInput;
-  update: UserUpdateWithoutRsvpsDataInput;
-  create: UserCreateWithoutRsvpsInput;
+  update: UserUpdateWithoutSavedDataInput;
+  create: UserCreateWithoutSavedInput;
 }
 
 export interface EventUpsertWithWhereUniqueWithoutAdminsInput {
   where: EventWhereUniqueInput;
   update: EventUpdateWithoutAdminsDataInput;
   create: EventCreateWithoutAdminsInput;
+}
+
+export interface UserUpsertWithWhereUniqueWithoutRsvpsInput {
+  where: UserWhereUniqueInput;
+  update: UserUpdateWithoutRsvpsDataInput;
+  create: UserCreateWithoutRsvpsInput;
+}
+
+export interface EventUpsertWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput;
+  update: EventUpdateWithoutSavedDataInput;
+  create: EventCreateWithoutSavedInput;
 }
 
 export interface UserUpsertWithoutCreatedImagesInput {
@@ -2523,6 +2675,7 @@ export interface EventCreateWithoutUrlsInput {
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
   tags?: Maybe<TagCreateManyWithoutEventsInput>;
@@ -2550,6 +2703,7 @@ export interface EventUpdateWithoutUrlsDataInput {
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
   tags?: Maybe<TagUpdateManyWithoutEventsInput>;
@@ -2617,6 +2771,7 @@ export interface EventCreateWithoutLocationsInput {
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   tags?: Maybe<TagCreateManyWithoutEventsInput>;
@@ -2696,6 +2851,7 @@ export interface EventUpdateWithoutLocationsDataInput {
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   tags?: Maybe<TagUpdateManyWithoutEventsInput>;
@@ -2793,6 +2949,7 @@ export interface UserCreateWithoutOrganizationsInput {
   lastName?: Maybe<String>;
   auth0Id: String;
   rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
   adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
@@ -2838,6 +2995,7 @@ export interface UserUpdateWithoutOrganizationsDataInput {
   lastName?: Maybe<String>;
   auth0Id?: Maybe<String>;
   rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
   adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
@@ -2877,6 +3035,7 @@ export interface EventCreateWithoutTagsInput {
   creator?: Maybe<UserCreateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageCreateManyWithoutEventInput>;
   rsvps?: Maybe<UserCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserCreateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlCreateManyWithoutEventInput>;
   admins?: Maybe<UserCreateManyWithoutAdminForInput>;
   locations?: Maybe<LocationCreateManyWithoutEventInput>;
@@ -2922,6 +3081,7 @@ export interface EventUpdateWithoutTagsDataInput {
   creator?: Maybe<UserUpdateOneWithoutCreatedEventsInput>;
   eventImages?: Maybe<EventImageUpdateManyWithoutEventInput>;
   rsvps?: Maybe<UserUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<UserUpdateManyWithoutSavedInput>;
   urls?: Maybe<EventUrlUpdateManyWithoutEventInput>;
   admins?: Maybe<UserUpdateManyWithoutAdminForInput>;
   locations?: Maybe<LocationUpdateManyWithoutEventInput>;
@@ -2945,6 +3105,7 @@ export interface UserCreateInput {
   auth0Id: String;
   organizations?: Maybe<OrganizationCreateManyWithoutUsersInput>;
   rsvps?: Maybe<EventCreateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventCreateManyWithoutSavedInput>;
   adminFor?: Maybe<EventCreateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventCreateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageCreateManyWithoutCreatorInput>;
@@ -2956,6 +3117,7 @@ export interface UserUpdateInput {
   auth0Id?: Maybe<String>;
   organizations?: Maybe<OrganizationUpdateManyWithoutUsersInput>;
   rsvps?: Maybe<EventUpdateManyWithoutRsvpsInput>;
+  saved?: Maybe<EventUpdateManyWithoutSavedInput>;
   adminFor?: Maybe<EventUpdateManyWithoutAdminsInput>;
   createdEvents?: Maybe<EventUpdateManyWithoutCreatorInput>;
   createdImages?: Maybe<EventImageUpdateManyWithoutCreatorInput>;
@@ -3132,6 +3294,15 @@ export interface EventPromise extends Promise<Event>, Fragmentable {
     first?: Int;
     last?: Int;
   }) => T;
+  saved: <T = FragmentableArray<User>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
   urls: <T = FragmentableArray<EventUrl>>(args?: {
     where?: EventUrlWhereInput;
     orderBy?: EventUrlOrderByInput;
@@ -3199,6 +3370,15 @@ export interface EventSubscription
     first?: Int;
     last?: Int;
   }) => T;
+  saved: <T = Promise<AsyncIterator<UserSubscription>>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
   urls: <T = Promise<AsyncIterator<EventUrlSubscription>>>(args?: {
     where?: EventUrlWhereInput;
     orderBy?: EventUrlOrderByInput;
@@ -3258,6 +3438,15 @@ export interface EventNullablePromise
     last?: Int;
   }) => T;
   rsvps: <T = FragmentableArray<User>>(args?: {
+    where?: UserWhereInput;
+    orderBy?: UserOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  saved: <T = FragmentableArray<User>>(args?: {
     where?: UserWhereInput;
     orderBy?: UserOrderByInput;
     skip?: Int;
@@ -3335,6 +3524,15 @@ export interface UserPromise extends Promise<User>, Fragmentable {
     first?: Int;
     last?: Int;
   }) => T;
+  saved: <T = FragmentableArray<Event>>(args?: {
+    where?: EventWhereInput;
+    orderBy?: EventOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
   adminFor: <T = FragmentableArray<Event>>(args?: {
     where?: EventWhereInput;
     orderBy?: EventOrderByInput;
@@ -3389,6 +3587,15 @@ export interface UserSubscription
     first?: Int;
     last?: Int;
   }) => T;
+  saved: <T = Promise<AsyncIterator<EventSubscription>>>(args?: {
+    where?: EventWhereInput;
+    orderBy?: EventOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
   adminFor: <T = Promise<AsyncIterator<EventSubscription>>>(args?: {
     where?: EventWhereInput;
     orderBy?: EventOrderByInput;
@@ -3435,6 +3642,15 @@ export interface UserNullablePromise
     last?: Int;
   }) => T;
   rsvps: <T = FragmentableArray<Event>>(args?: {
+    where?: EventWhereInput;
+    orderBy?: EventOrderByInput;
+    skip?: Int;
+    after?: String;
+    before?: String;
+    first?: Int;
+    last?: Int;
+  }) => T;
+  saved: <T = FragmentableArray<Event>>(args?: {
     where?: EventWhereInput;
     orderBy?: EventOrderByInput;
     skip?: Int;

--- a/prisma-client/generated/prisma-client/prisma-schema.js
+++ b/prisma-client/generated/prisma-client/prisma-schema.js
@@ -55,6 +55,7 @@ type Event {
   creator: User
   eventImages(where: EventImageWhereInput, orderBy: EventImageOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventImage!]
   rsvps(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
+  saved(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   urls(where: EventUrlWhereInput, orderBy: EventUrlOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventUrl!]
   admins(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   locations(where: LocationWhereInput, orderBy: LocationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Location!]
@@ -78,6 +79,7 @@ input EventCreateInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -97,6 +99,11 @@ input EventCreateManyWithoutCreatorInput {
 
 input EventCreateManyWithoutRsvpsInput {
   create: [EventCreateWithoutRsvpsInput!]
+  connect: [EventWhereUniqueInput!]
+}
+
+input EventCreateManyWithoutSavedInput {
+  create: [EventCreateWithoutSavedInput!]
   connect: [EventWhereUniqueInput!]
 }
 
@@ -130,6 +137,7 @@ input EventCreateWithoutAdminsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   locations: LocationCreateManyWithoutEventInput
   tags: TagCreateManyWithoutEventsInput
@@ -145,6 +153,7 @@ input EventCreateWithoutCreatorInput {
   ticketPrice: Float!
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -161,6 +170,7 @@ input EventCreateWithoutEventImagesInput {
   ticketPrice: Float!
   creator: UserCreateOneWithoutCreatedEventsInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -178,6 +188,7 @@ input EventCreateWithoutLocationsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   tags: TagCreateManyWithoutEventsInput
@@ -193,6 +204,24 @@ input EventCreateWithoutRsvpsInput {
   ticketPrice: Float!
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
+  saved: UserCreateManyWithoutSavedInput
+  urls: EventUrlCreateManyWithoutEventInput
+  admins: UserCreateManyWithoutAdminForInput
+  locations: LocationCreateManyWithoutEventInput
+  tags: TagCreateManyWithoutEventsInput
+  index: String!
+}
+
+input EventCreateWithoutSavedInput {
+  id: ID
+  title: String!
+  description: String!
+  start: DateTime!
+  end: DateTime!
+  ticketPrice: Float!
+  creator: UserCreateOneWithoutCreatedEventsInput
+  eventImages: EventImageCreateManyWithoutEventInput
+  rsvps: UserCreateManyWithoutRsvpsInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -210,6 +239,7 @@ input EventCreateWithoutTagsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -226,6 +256,7 @@ input EventCreateWithoutUrlsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
   tags: TagCreateManyWithoutEventsInput
@@ -603,6 +634,7 @@ input EventUpdateInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -664,6 +696,18 @@ input EventUpdateManyWithoutRsvpsInput {
   updateMany: [EventUpdateManyWithWhereNestedInput!]
 }
 
+input EventUpdateManyWithoutSavedInput {
+  create: [EventCreateWithoutSavedInput!]
+  delete: [EventWhereUniqueInput!]
+  connect: [EventWhereUniqueInput!]
+  set: [EventWhereUniqueInput!]
+  disconnect: [EventWhereUniqueInput!]
+  update: [EventUpdateWithWhereUniqueWithoutSavedInput!]
+  upsert: [EventUpsertWithWhereUniqueWithoutSavedInput!]
+  deleteMany: [EventScalarWhereInput!]
+  updateMany: [EventUpdateManyWithWhereNestedInput!]
+}
+
 input EventUpdateManyWithoutTagsInput {
   create: [EventCreateWithoutTagsInput!]
   delete: [EventWhereUniqueInput!]
@@ -713,6 +757,7 @@ input EventUpdateWithoutAdminsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   locations: LocationUpdateManyWithoutEventInput
   tags: TagUpdateManyWithoutEventsInput
@@ -727,6 +772,7 @@ input EventUpdateWithoutCreatorDataInput {
   ticketPrice: Float
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -742,6 +788,7 @@ input EventUpdateWithoutEventImagesDataInput {
   ticketPrice: Float
   creator: UserUpdateOneWithoutCreatedEventsInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -758,6 +805,7 @@ input EventUpdateWithoutLocationsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   tags: TagUpdateManyWithoutEventsInput
@@ -772,6 +820,23 @@ input EventUpdateWithoutRsvpsDataInput {
   ticketPrice: Float
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
+  saved: UserUpdateManyWithoutSavedInput
+  urls: EventUrlUpdateManyWithoutEventInput
+  admins: UserUpdateManyWithoutAdminForInput
+  locations: LocationUpdateManyWithoutEventInput
+  tags: TagUpdateManyWithoutEventsInput
+  index: String
+}
+
+input EventUpdateWithoutSavedDataInput {
+  title: String
+  description: String
+  start: DateTime
+  end: DateTime
+  ticketPrice: Float
+  creator: UserUpdateOneWithoutCreatedEventsInput
+  eventImages: EventImageUpdateManyWithoutEventInput
+  rsvps: UserUpdateManyWithoutRsvpsInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -788,6 +853,7 @@ input EventUpdateWithoutTagsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -803,6 +869,7 @@ input EventUpdateWithoutUrlsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
   tags: TagUpdateManyWithoutEventsInput
@@ -822,6 +889,11 @@ input EventUpdateWithWhereUniqueWithoutCreatorInput {
 input EventUpdateWithWhereUniqueWithoutRsvpsInput {
   where: EventWhereUniqueInput!
   data: EventUpdateWithoutRsvpsDataInput!
+}
+
+input EventUpdateWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput!
+  data: EventUpdateWithoutSavedDataInput!
 }
 
 input EventUpdateWithWhereUniqueWithoutTagsInput {
@@ -860,6 +932,12 @@ input EventUpsertWithWhereUniqueWithoutRsvpsInput {
   where: EventWhereUniqueInput!
   update: EventUpdateWithoutRsvpsDataInput!
   create: EventCreateWithoutRsvpsInput!
+}
+
+input EventUpsertWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput!
+  update: EventUpdateWithoutSavedDataInput!
+  create: EventCreateWithoutSavedInput!
 }
 
 input EventUpsertWithWhereUniqueWithoutTagsInput {
@@ -1123,6 +1201,9 @@ input EventWhereInput {
   rsvps_every: UserWhereInput
   rsvps_some: UserWhereInput
   rsvps_none: UserWhereInput
+  saved_every: UserWhereInput
+  saved_some: UserWhereInput
+  saved_none: UserWhereInput
   urls_every: EventUrlWhereInput
   urls_some: EventUrlWhereInput
   urls_none: EventUrlWhereInput
@@ -2498,6 +2579,7 @@ type User {
   auth0Id: String!
   organizations(where: OrganizationWhereInput, orderBy: OrganizationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Organization!]
   rsvps(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
+  saved(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   adminFor(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   createdEvents(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   createdImages(where: EventImageWhereInput, orderBy: EventImageOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventImage!]
@@ -2516,6 +2598,7 @@ input UserCreateInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2536,6 +2619,11 @@ input UserCreateManyWithoutRsvpsInput {
   connect: [UserWhereUniqueInput!]
 }
 
+input UserCreateManyWithoutSavedInput {
+  create: [UserCreateWithoutSavedInput!]
+  connect: [UserWhereUniqueInput!]
+}
+
 input UserCreateOneWithoutCreatedEventsInput {
   create: UserCreateWithoutCreatedEventsInput
   connect: UserWhereUniqueInput
@@ -2553,6 +2641,7 @@ input UserCreateWithoutAdminForInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
 }
@@ -2564,6 +2653,7 @@ input UserCreateWithoutCreatedEventsInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdImages: EventImageCreateManyWithoutCreatorInput
 }
@@ -2575,6 +2665,7 @@ input UserCreateWithoutCreatedImagesInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
 }
@@ -2585,6 +2676,7 @@ input UserCreateWithoutOrganizationsInput {
   lastName: String
   auth0Id: String!
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2596,6 +2688,19 @@ input UserCreateWithoutRsvpsInput {
   lastName: String
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
+  saved: EventCreateManyWithoutSavedInput
+  adminFor: EventCreateManyWithoutAdminsInput
+  createdEvents: EventCreateManyWithoutCreatorInput
+  createdImages: EventImageCreateManyWithoutCreatorInput
+}
+
+input UserCreateWithoutSavedInput {
+  id: ID
+  firstName: String
+  lastName: String
+  auth0Id: String!
+  organizations: OrganizationCreateManyWithoutUsersInput
+  rsvps: EventCreateManyWithoutRsvpsInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2710,6 +2815,7 @@ input UserUpdateInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2763,6 +2869,18 @@ input UserUpdateManyWithoutRsvpsInput {
   updateMany: [UserUpdateManyWithWhereNestedInput!]
 }
 
+input UserUpdateManyWithoutSavedInput {
+  create: [UserCreateWithoutSavedInput!]
+  delete: [UserWhereUniqueInput!]
+  connect: [UserWhereUniqueInput!]
+  set: [UserWhereUniqueInput!]
+  disconnect: [UserWhereUniqueInput!]
+  update: [UserUpdateWithWhereUniqueWithoutSavedInput!]
+  upsert: [UserUpsertWithWhereUniqueWithoutSavedInput!]
+  deleteMany: [UserScalarWhereInput!]
+  updateMany: [UserUpdateManyWithWhereNestedInput!]
+}
+
 input UserUpdateManyWithWhereNestedInput {
   where: UserScalarWhereInput!
   data: UserUpdateManyDataInput!
@@ -2790,6 +2908,7 @@ input UserUpdateWithoutAdminForDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
 }
@@ -2800,6 +2919,7 @@ input UserUpdateWithoutCreatedEventsDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
 }
@@ -2810,6 +2930,7 @@ input UserUpdateWithoutCreatedImagesDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
 }
@@ -2819,6 +2940,7 @@ input UserUpdateWithoutOrganizationsDataInput {
   lastName: String
   auth0Id: String
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2829,6 +2951,18 @@ input UserUpdateWithoutRsvpsDataInput {
   lastName: String
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
+  saved: EventUpdateManyWithoutSavedInput
+  adminFor: EventUpdateManyWithoutAdminsInput
+  createdEvents: EventUpdateManyWithoutCreatorInput
+  createdImages: EventImageUpdateManyWithoutCreatorInput
+}
+
+input UserUpdateWithoutSavedDataInput {
+  firstName: String
+  lastName: String
+  auth0Id: String
+  organizations: OrganizationUpdateManyWithoutUsersInput
+  rsvps: EventUpdateManyWithoutRsvpsInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2847,6 +2981,11 @@ input UserUpdateWithWhereUniqueWithoutOrganizationsInput {
 input UserUpdateWithWhereUniqueWithoutRsvpsInput {
   where: UserWhereUniqueInput!
   data: UserUpdateWithoutRsvpsDataInput!
+}
+
+input UserUpdateWithWhereUniqueWithoutSavedInput {
+  where: UserWhereUniqueInput!
+  data: UserUpdateWithoutSavedDataInput!
 }
 
 input UserUpsertWithoutCreatedEventsInput {
@@ -2875,6 +3014,12 @@ input UserUpsertWithWhereUniqueWithoutRsvpsInput {
   where: UserWhereUniqueInput!
   update: UserUpdateWithoutRsvpsDataInput!
   create: UserCreateWithoutRsvpsInput!
+}
+
+input UserUpsertWithWhereUniqueWithoutSavedInput {
+  where: UserWhereUniqueInput!
+  update: UserUpdateWithoutSavedDataInput!
+  create: UserCreateWithoutSavedInput!
 }
 
 input UserWhereInput {
@@ -2940,6 +3085,9 @@ input UserWhereInput {
   rsvps_every: EventWhereInput
   rsvps_some: EventWhereInput
   rsvps_none: EventWhereInput
+  saved_every: EventWhereInput
+  saved_some: EventWhereInput
+  saved_none: EventWhereInput
   adminFor_every: EventWhereInput
   adminFor_some: EventWhereInput
   adminFor_none: EventWhereInput

--- a/prisma-client/generated/prisma.graphql
+++ b/prisma-client/generated/prisma.graphql
@@ -50,6 +50,7 @@ type Event {
   creator: User
   eventImages(where: EventImageWhereInput, orderBy: EventImageOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventImage!]
   rsvps(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
+  saved(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   urls(where: EventUrlWhereInput, orderBy: EventUrlOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventUrl!]
   admins(where: UserWhereInput, orderBy: UserOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [User!]
   locations(where: LocationWhereInput, orderBy: LocationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Location!]
@@ -73,6 +74,7 @@ input EventCreateInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -92,6 +94,11 @@ input EventCreateManyWithoutCreatorInput {
 
 input EventCreateManyWithoutRsvpsInput {
   create: [EventCreateWithoutRsvpsInput!]
+  connect: [EventWhereUniqueInput!]
+}
+
+input EventCreateManyWithoutSavedInput {
+  create: [EventCreateWithoutSavedInput!]
   connect: [EventWhereUniqueInput!]
 }
 
@@ -125,6 +132,7 @@ input EventCreateWithoutAdminsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   locations: LocationCreateManyWithoutEventInput
   tags: TagCreateManyWithoutEventsInput
@@ -140,6 +148,7 @@ input EventCreateWithoutCreatorInput {
   ticketPrice: Float!
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -156,6 +165,7 @@ input EventCreateWithoutEventImagesInput {
   ticketPrice: Float!
   creator: UserCreateOneWithoutCreatedEventsInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -173,6 +183,7 @@ input EventCreateWithoutLocationsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   tags: TagCreateManyWithoutEventsInput
@@ -188,6 +199,24 @@ input EventCreateWithoutRsvpsInput {
   ticketPrice: Float!
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
+  saved: UserCreateManyWithoutSavedInput
+  urls: EventUrlCreateManyWithoutEventInput
+  admins: UserCreateManyWithoutAdminForInput
+  locations: LocationCreateManyWithoutEventInput
+  tags: TagCreateManyWithoutEventsInput
+  index: String!
+}
+
+input EventCreateWithoutSavedInput {
+  id: ID
+  title: String!
+  description: String!
+  start: DateTime!
+  end: DateTime!
+  ticketPrice: Float!
+  creator: UserCreateOneWithoutCreatedEventsInput
+  eventImages: EventImageCreateManyWithoutEventInput
+  rsvps: UserCreateManyWithoutRsvpsInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -205,6 +234,7 @@ input EventCreateWithoutTagsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   urls: EventUrlCreateManyWithoutEventInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
@@ -221,6 +251,7 @@ input EventCreateWithoutUrlsInput {
   creator: UserCreateOneWithoutCreatedEventsInput
   eventImages: EventImageCreateManyWithoutEventInput
   rsvps: UserCreateManyWithoutRsvpsInput
+  saved: UserCreateManyWithoutSavedInput
   admins: UserCreateManyWithoutAdminForInput
   locations: LocationCreateManyWithoutEventInput
   tags: TagCreateManyWithoutEventsInput
@@ -598,6 +629,7 @@ input EventUpdateInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -659,6 +691,18 @@ input EventUpdateManyWithoutRsvpsInput {
   updateMany: [EventUpdateManyWithWhereNestedInput!]
 }
 
+input EventUpdateManyWithoutSavedInput {
+  create: [EventCreateWithoutSavedInput!]
+  delete: [EventWhereUniqueInput!]
+  connect: [EventWhereUniqueInput!]
+  set: [EventWhereUniqueInput!]
+  disconnect: [EventWhereUniqueInput!]
+  update: [EventUpdateWithWhereUniqueWithoutSavedInput!]
+  upsert: [EventUpsertWithWhereUniqueWithoutSavedInput!]
+  deleteMany: [EventScalarWhereInput!]
+  updateMany: [EventUpdateManyWithWhereNestedInput!]
+}
+
 input EventUpdateManyWithoutTagsInput {
   create: [EventCreateWithoutTagsInput!]
   delete: [EventWhereUniqueInput!]
@@ -708,6 +752,7 @@ input EventUpdateWithoutAdminsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   locations: LocationUpdateManyWithoutEventInput
   tags: TagUpdateManyWithoutEventsInput
@@ -722,6 +767,7 @@ input EventUpdateWithoutCreatorDataInput {
   ticketPrice: Float
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -737,6 +783,7 @@ input EventUpdateWithoutEventImagesDataInput {
   ticketPrice: Float
   creator: UserUpdateOneWithoutCreatedEventsInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -753,6 +800,7 @@ input EventUpdateWithoutLocationsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   tags: TagUpdateManyWithoutEventsInput
@@ -767,6 +815,23 @@ input EventUpdateWithoutRsvpsDataInput {
   ticketPrice: Float
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
+  saved: UserUpdateManyWithoutSavedInput
+  urls: EventUrlUpdateManyWithoutEventInput
+  admins: UserUpdateManyWithoutAdminForInput
+  locations: LocationUpdateManyWithoutEventInput
+  tags: TagUpdateManyWithoutEventsInput
+  index: String
+}
+
+input EventUpdateWithoutSavedDataInput {
+  title: String
+  description: String
+  start: DateTime
+  end: DateTime
+  ticketPrice: Float
+  creator: UserUpdateOneWithoutCreatedEventsInput
+  eventImages: EventImageUpdateManyWithoutEventInput
+  rsvps: UserUpdateManyWithoutRsvpsInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -783,6 +848,7 @@ input EventUpdateWithoutTagsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   urls: EventUrlUpdateManyWithoutEventInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
@@ -798,6 +864,7 @@ input EventUpdateWithoutUrlsDataInput {
   creator: UserUpdateOneWithoutCreatedEventsInput
   eventImages: EventImageUpdateManyWithoutEventInput
   rsvps: UserUpdateManyWithoutRsvpsInput
+  saved: UserUpdateManyWithoutSavedInput
   admins: UserUpdateManyWithoutAdminForInput
   locations: LocationUpdateManyWithoutEventInput
   tags: TagUpdateManyWithoutEventsInput
@@ -817,6 +884,11 @@ input EventUpdateWithWhereUniqueWithoutCreatorInput {
 input EventUpdateWithWhereUniqueWithoutRsvpsInput {
   where: EventWhereUniqueInput!
   data: EventUpdateWithoutRsvpsDataInput!
+}
+
+input EventUpdateWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput!
+  data: EventUpdateWithoutSavedDataInput!
 }
 
 input EventUpdateWithWhereUniqueWithoutTagsInput {
@@ -855,6 +927,12 @@ input EventUpsertWithWhereUniqueWithoutRsvpsInput {
   where: EventWhereUniqueInput!
   update: EventUpdateWithoutRsvpsDataInput!
   create: EventCreateWithoutRsvpsInput!
+}
+
+input EventUpsertWithWhereUniqueWithoutSavedInput {
+  where: EventWhereUniqueInput!
+  update: EventUpdateWithoutSavedDataInput!
+  create: EventCreateWithoutSavedInput!
 }
 
 input EventUpsertWithWhereUniqueWithoutTagsInput {
@@ -1118,6 +1196,9 @@ input EventWhereInput {
   rsvps_every: UserWhereInput
   rsvps_some: UserWhereInput
   rsvps_none: UserWhereInput
+  saved_every: UserWhereInput
+  saved_some: UserWhereInput
+  saved_none: UserWhereInput
   urls_every: EventUrlWhereInput
   urls_some: EventUrlWhereInput
   urls_none: EventUrlWhereInput
@@ -2493,6 +2574,7 @@ type User {
   auth0Id: String!
   organizations(where: OrganizationWhereInput, orderBy: OrganizationOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Organization!]
   rsvps(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
+  saved(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   adminFor(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   createdEvents(where: EventWhereInput, orderBy: EventOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [Event!]
   createdImages(where: EventImageWhereInput, orderBy: EventImageOrderByInput, skip: Int, after: String, before: String, first: Int, last: Int): [EventImage!]
@@ -2511,6 +2593,7 @@ input UserCreateInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2531,6 +2614,11 @@ input UserCreateManyWithoutRsvpsInput {
   connect: [UserWhereUniqueInput!]
 }
 
+input UserCreateManyWithoutSavedInput {
+  create: [UserCreateWithoutSavedInput!]
+  connect: [UserWhereUniqueInput!]
+}
+
 input UserCreateOneWithoutCreatedEventsInput {
   create: UserCreateWithoutCreatedEventsInput
   connect: UserWhereUniqueInput
@@ -2548,6 +2636,7 @@ input UserCreateWithoutAdminForInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
 }
@@ -2559,6 +2648,7 @@ input UserCreateWithoutCreatedEventsInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdImages: EventImageCreateManyWithoutCreatorInput
 }
@@ -2570,6 +2660,7 @@ input UserCreateWithoutCreatedImagesInput {
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
 }
@@ -2580,6 +2671,7 @@ input UserCreateWithoutOrganizationsInput {
   lastName: String
   auth0Id: String!
   rsvps: EventCreateManyWithoutRsvpsInput
+  saved: EventCreateManyWithoutSavedInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2591,6 +2683,19 @@ input UserCreateWithoutRsvpsInput {
   lastName: String
   auth0Id: String!
   organizations: OrganizationCreateManyWithoutUsersInput
+  saved: EventCreateManyWithoutSavedInput
+  adminFor: EventCreateManyWithoutAdminsInput
+  createdEvents: EventCreateManyWithoutCreatorInput
+  createdImages: EventImageCreateManyWithoutCreatorInput
+}
+
+input UserCreateWithoutSavedInput {
+  id: ID
+  firstName: String
+  lastName: String
+  auth0Id: String!
+  organizations: OrganizationCreateManyWithoutUsersInput
+  rsvps: EventCreateManyWithoutRsvpsInput
   adminFor: EventCreateManyWithoutAdminsInput
   createdEvents: EventCreateManyWithoutCreatorInput
   createdImages: EventImageCreateManyWithoutCreatorInput
@@ -2705,6 +2810,7 @@ input UserUpdateInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2758,6 +2864,18 @@ input UserUpdateManyWithoutRsvpsInput {
   updateMany: [UserUpdateManyWithWhereNestedInput!]
 }
 
+input UserUpdateManyWithoutSavedInput {
+  create: [UserCreateWithoutSavedInput!]
+  delete: [UserWhereUniqueInput!]
+  connect: [UserWhereUniqueInput!]
+  set: [UserWhereUniqueInput!]
+  disconnect: [UserWhereUniqueInput!]
+  update: [UserUpdateWithWhereUniqueWithoutSavedInput!]
+  upsert: [UserUpsertWithWhereUniqueWithoutSavedInput!]
+  deleteMany: [UserScalarWhereInput!]
+  updateMany: [UserUpdateManyWithWhereNestedInput!]
+}
+
 input UserUpdateManyWithWhereNestedInput {
   where: UserScalarWhereInput!
   data: UserUpdateManyDataInput!
@@ -2785,6 +2903,7 @@ input UserUpdateWithoutAdminForDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
 }
@@ -2795,6 +2914,7 @@ input UserUpdateWithoutCreatedEventsDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
 }
@@ -2805,6 +2925,7 @@ input UserUpdateWithoutCreatedImagesDataInput {
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
 }
@@ -2814,6 +2935,7 @@ input UserUpdateWithoutOrganizationsDataInput {
   lastName: String
   auth0Id: String
   rsvps: EventUpdateManyWithoutRsvpsInput
+  saved: EventUpdateManyWithoutSavedInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2824,6 +2946,18 @@ input UserUpdateWithoutRsvpsDataInput {
   lastName: String
   auth0Id: String
   organizations: OrganizationUpdateManyWithoutUsersInput
+  saved: EventUpdateManyWithoutSavedInput
+  adminFor: EventUpdateManyWithoutAdminsInput
+  createdEvents: EventUpdateManyWithoutCreatorInput
+  createdImages: EventImageUpdateManyWithoutCreatorInput
+}
+
+input UserUpdateWithoutSavedDataInput {
+  firstName: String
+  lastName: String
+  auth0Id: String
+  organizations: OrganizationUpdateManyWithoutUsersInput
+  rsvps: EventUpdateManyWithoutRsvpsInput
   adminFor: EventUpdateManyWithoutAdminsInput
   createdEvents: EventUpdateManyWithoutCreatorInput
   createdImages: EventImageUpdateManyWithoutCreatorInput
@@ -2842,6 +2976,11 @@ input UserUpdateWithWhereUniqueWithoutOrganizationsInput {
 input UserUpdateWithWhereUniqueWithoutRsvpsInput {
   where: UserWhereUniqueInput!
   data: UserUpdateWithoutRsvpsDataInput!
+}
+
+input UserUpdateWithWhereUniqueWithoutSavedInput {
+  where: UserWhereUniqueInput!
+  data: UserUpdateWithoutSavedDataInput!
 }
 
 input UserUpsertWithoutCreatedEventsInput {
@@ -2870,6 +3009,12 @@ input UserUpsertWithWhereUniqueWithoutRsvpsInput {
   where: UserWhereUniqueInput!
   update: UserUpdateWithoutRsvpsDataInput!
   create: UserCreateWithoutRsvpsInput!
+}
+
+input UserUpsertWithWhereUniqueWithoutSavedInput {
+  where: UserWhereUniqueInput!
+  update: UserUpdateWithoutSavedDataInput!
+  create: UserCreateWithoutSavedInput!
 }
 
 input UserWhereInput {
@@ -2935,6 +3080,9 @@ input UserWhereInput {
   rsvps_every: EventWhereInput
   rsvps_some: EventWhereInput
   rsvps_none: EventWhereInput
+  saved_every: EventWhereInput
+  saved_some: EventWhereInput
+  saved_none: EventWhereInput
   adminFor_every: EventWhereInput
   adminFor_some: EventWhereInput
   adminFor_none: EventWhereInput


### PR DESCRIPTION
- updated datamodel/schema with saved as a relation between events and users
- added a single mutation/resolver saveEvent which returns an enum type of `SAVED` or `UNSAVED`
- resolver will connect/discconnect user to/from event depending if user has already saved the event

Example: 
```
mutation {
	saveEvent(event: {id: "eventid123"})
}
```