### PR TITLE
fix distance orderby bug

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -268,6 +268,7 @@ const resolvers = {
         const userCircle = circle(center, radius, {steps: 10, units: 'miles'});
 
         return prisma.events({
+          ...args,
           where: {
             id_in: eventsInSquare
               .filter(event =>


### PR DESCRIPTION
Fixed bug where `locationFilter` args cause the `orderBy` are not to resolve.

`args` was not spread in to the final `prisma.events(...)` query

expected behavior achieved on deployed development server

Fixes issue #47 